### PR TITLE
Rewrite vision usage to make it more consistent and less confusing

### DIFF
--- a/simgui.json
+++ b/simgui.json
@@ -28,7 +28,6 @@
       },
       "/SmartDashboard/Field": {
         "height": 8.013679504394531,
-        "image": "/Users/jasonholt/Downloads/2024-field.png",
         "width": 16.541748046875,
         "window": {
           "visible": true

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -197,7 +197,7 @@ public final class Constants {
     public static final double kTiltPitch = 65; //11? tilt angle=
   }
 
-    public static class Vision {
+    public static class VisionConstants {
         public static final String kCameraNameTag = "Microsoft_LifeCam_HD-3000";
         public static final String kCameraNameNote = "Microsoft_LifeCam_VX-5000";
         // Cam mounted facing forward, half a meter forward of center, half a meter up from center.
@@ -212,6 +212,15 @@ public final class Constants {
         // (Fake values. Experiment and determine estimation noise on an actual robot.)
         public static final Matrix<N3, N1> kSingleTagStdDevs = VecBuilder.fill(4, 4, 8);
         public static final Matrix<N3, N1> kMultiTagStdDevs = VecBuilder.fill(0.5, 0.5, 1);
+        public static final double CAMERA_HEIGHT_METERS = Units.inchesToMeters(24);
+
+        public static final double TARGET_HEIGHT_METERS = Units.feetToMeters(5);
+        // Angle between horizontal and the camera.
+        public static final double CAMERA_PITCH_RADIANS = Units.degreesToRadians(0);
+    
+        // How far from the target we want to be
+        public static final double GOAL_RANGE_METERS = Units.feetToMeters(3);
+
     }
     
     public static class ShootNoteConstants {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,9 +4,14 @@
 
 package frc.robot;
 
+import static frc.robot.Constants.VisionConstants.kCameraNameNote;
+import static frc.robot.Constants.VisionConstants.kCameraNameTag;
+
 import java.sql.JDBCType;
 import java.util.ArrayList;
 import java.util.HashMap;
+
+import org.photonvision.PhotonCamera;
 
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.auto.NamedCommands;
@@ -59,13 +64,17 @@ import frc.robot.subsystems.Shooter;
 public class RobotContainer {
   private final SendableChooser<Command> autoChooser;
   //private Vision visionSim;
-  
-private Vision m_simVision = new Vision();
-private final Navigation m_vision = new Navigation();
+
+private PhotonCamera cameraTag = new PhotonCamera(kCameraNameTag);
+private PhotonCamera cameraNote = new PhotonCamera(kCameraNameNote);
+private Vision m_tagVision = new Vision(cameraTag);
+private Vision m_noteVision = new Vision(cameraNote);
+
+private final Navigation m_vision = new Navigation(m_tagVision);
 private final Shooter m_robotShooter = new Shooter();
 private final Intake m_robotIntake = new Intake();
-private final NoteFinder m_NoteFinder = new NoteFinder(m_simVision);
-private final DriveSubsystem m_robotDrive = new DriveSubsystem(m_simVision);
+private final NoteFinder m_NoteFinder = new NoteFinder(m_noteVision);
+private final DriveSubsystem m_robotDrive = new DriveSubsystem(m_tagVision);
 private final Neck m_Neck = new Neck();
 
   // The driver's controller
@@ -135,7 +144,7 @@ private final Neck m_Neck = new Neck();
         .whileTrue(new PickUpNote(m_robotIntake));
 
     new JoystickButton(m_gunnerController, Button.kB.value)
-        .whileTrue(new GetChosenTarget(m_vision, m_robotDrive));
+        .whileTrue(new GetChosenTarget(m_noteVision, m_robotDrive));
 
     new Trigger(() -> ( m_driverController.getLeftTriggerAxis() > 0.5))
         .whileTrue(new RunCommand(() -> m_robotShooter.setShooterSpeedFast(), m_robotShooter));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -20,6 +20,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.OIConstants;
 import frc.robot.commands.GetBestTarget;
+import frc.robot.commands.GetChosenTarget;
 import frc.robot.commands.GrabNote;
 import frc.robot.commands.MoveToClosestNote;
 import frc.robot.commands.PickUpNote;
@@ -132,6 +133,9 @@ private final Neck m_Neck = new Neck();
         .whileTrue(new ShootNote(m_robotShooter, m_robotIntake));
     new JoystickButton(m_driverController, Button.kY.value)
         .whileTrue(new PickUpNote(m_robotIntake));
+
+    new JoystickButton(m_gunnerController, Button.kB.value)
+        .whileTrue(new GetChosenTarget(m_vision, m_robotDrive));
 
     new Trigger(() -> ( m_driverController.getLeftTriggerAxis() > 0.5))
         .whileTrue(new RunCommand(() -> m_robotShooter.setShooterSpeedFast(), m_robotShooter));

--- a/src/main/java/frc/robot/Vision.java
+++ b/src/main/java/frc/robot/Vision.java
@@ -24,7 +24,7 @@
 
 package frc.robot;
 
-import static frc.robot.Constants.Vision.*;
+import static frc.robot.Constants.VisionConstants.*;
 
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
@@ -32,20 +32,27 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
+import frc.robot.Constants.VisionConstants;
+import frc.robot.subsystems.DriveSubsystem;
+
+import java.util.List;
 import java.util.Optional;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonPoseEstimator;
 import org.photonvision.PhotonPoseEstimator.PoseStrategy;
+import org.photonvision.PhotonUtils;
 import org.photonvision.simulation.PhotonCameraSim;
 import org.photonvision.simulation.SimCameraProperties;
 import org.photonvision.simulation.VisionSystemSim;
 import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
 
 public class Vision {
-    private final PhotonCamera cameraTag;
-    private final PhotonCamera cameraNote;
+    private final PhotonCamera m_camera;
+    // private final PhotonCamera cameraNote;
     private final PhotonPoseEstimator photonEstimator;
     private double lastEstTimestamp = 0;
 
@@ -53,31 +60,33 @@ public class Vision {
     private PhotonCameraSim cameraSim;
     private VisionSystemSim visionSim;
 
-    public Vision() {
-        cameraTag = new PhotonCamera(kCameraNameTag);
-        cameraNote = new PhotonCamera(kCameraNameNote);
+    public Vision(PhotonCamera camera) {
+        m_camera = camera;
 
-        photonEstimator =
-                new PhotonPoseEstimator(
-                        kTagLayout, PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR, cameraTag, kRobotToCam);
+        photonEstimator = new PhotonPoseEstimator(
+                kTagLayout, PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR, m_camera, kRobotToCam);
         photonEstimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);
 
         // ----- Simulation
         if (Robot.isSimulation()) {
-            // Create the vision system simulation which handles cameras and targets on the field.
+            // Create the vision system simulation which handles cameras and targets on the
+            // field.
             visionSim = new VisionSystemSim("main");
-            // Add all the AprilTags inside the tag layout as visible targets to this simulated field.
+            // Add all the AprilTags inside the tag layout as visible targets to this
+            // simulated field.
             visionSim.addAprilTags(kTagLayout);
-            // Create simulated camera properties. These can be set to mimic your actual camera.
+            // Create simulated camera properties. These can be set to mimic your actual
+            // camera.
             var cameraProp = new SimCameraProperties();
             cameraProp.setCalibration(960, 720, Rotation2d.fromDegrees(90));
             cameraProp.setCalibError(0.35, 0.10);
             cameraProp.setFPS(15);
             cameraProp.setAvgLatencyMs(50);
             cameraProp.setLatencyStdDevMs(15);
-            // Create a PhotonCameraSim which will update the linked PhotonCamera's values with visible
+            // Create a PhotonCameraSim which will update the linked PhotonCamera's values
+            // with visible
             // targets.
-            cameraSim = new PhotonCameraSim(cameraTag, cameraProp);
+            cameraSim = new PhotonCameraSim(m_camera, cameraProp);
             // Add the simulated camera to view the targets on this simulated field.
             visionSim.addCamera(cameraSim, kRobotToCam);
 
@@ -85,66 +94,74 @@ public class Vision {
         }
     }
 
-    public PhotonPipelineResult getLatestResult(String Cameraname) {
-        if (Cameraname.equals(kCameraNameTag))
-            return cameraTag.getLatestResult();
-        else
-            return cameraNote.getLatestResult();
+    public PhotonPipelineResult getLatestResult() {
+        return m_camera.getLatestResult();
     }
 
+    public PhotonPipelineResult getLatestCameraResult() {
+        return m_camera.getLatestResult();
+    }
 
     /**
-     * The latest estimated robot pose on the field from vision data. This may be empty. This should
+     * The latest estimated robot pose on the field from vision data. This may be
+     * empty. This should
      * only be called once per loop.
      *
-     * @return An {@link EstimatedRobotPose} with an estimated pose, estimate timestamp, and targets
-     *     used for estimation.
+     * @return An {@link EstimatedRobotPose} with an estimated pose, estimate
+     *         timestamp, and targets
+     *         used for estimation.
      */
     public Optional<EstimatedRobotPose> getEstimatedGlobalPose() {
         var visionEst = photonEstimator.update();
-        double latestTimestamp = cameraTag.getLatestResult().getTimestampSeconds();
+        double latestTimestamp = m_camera.getLatestResult().getTimestampSeconds();
         boolean newResult = Math.abs(latestTimestamp - lastEstTimestamp) > 1e-5;
         if (Robot.isSimulation()) {
             visionEst.ifPresentOrElse(
-                    est ->
-                            getSimDebugField()
-                                    .getObject("VisionEstimation")
-                                    .setPose(est.estimatedPose.toPose2d()),
+                    est -> getSimDebugField()
+                            .getObject("VisionEstimation")
+                            .setPose(est.estimatedPose.toPose2d()),
                     () -> {
-                        if (newResult) getSimDebugField().getObject("VisionEstimation").setPoses();
+                        if (newResult)
+                            getSimDebugField().getObject("VisionEstimation").setPoses();
                     });
         }
-        if (newResult) lastEstTimestamp = latestTimestamp;
+        if (newResult)
+            lastEstTimestamp = latestTimestamp;
         return visionEst;
     }
 
     /**
-     * The standard deviations of the estimated pose from {@link #getEstimatedGlobalPose()}, for use
-     * with {@link edu.wpi.first.math.estimator.SwerveDrivePoseEstimator SwerveDrivePoseEstimator}.
+     * The standard deviations of the estimated pose from
+     * {@link #getEstimatedGlobalPose()}, for use
+     * with {@link edu.wpi.first.math.estimator.SwerveDrivePoseEstimator
+     * SwerveDrivePoseEstimator}.
      * This should only be used when there are targets visible.
      *
      * @param estimatedPose The estimated pose to guess standard deviations for.
      */
     public Matrix<N3, N1> getEstimationStdDevs(Pose2d estimatedPose) {
         var estStdDevs = kSingleTagStdDevs;
-        var targets = getLatestResult(kCameraNameTag).getTargets();
+        var targets = getLatestResult().getTargets();
         int numTags = 0;
         double avgDist = 0;
         for (var tgt : targets) {
             var tagPose = photonEstimator.getFieldTags().getTagPose(tgt.getFiducialId());
-            if (tagPose.isEmpty()) continue;
+            if (tagPose.isEmpty())
+                continue;
             numTags++;
-            avgDist +=
-                    tagPose.get().toPose2d().getTranslation().getDistance(estimatedPose.getTranslation());
+            avgDist += tagPose.get().toPose2d().getTranslation().getDistance(estimatedPose.getTranslation());
         }
-        if (numTags == 0) return estStdDevs;
+        if (numTags == 0)
+            return estStdDevs;
         avgDist /= numTags;
         // Decrease std devs if multiple targets are visible
-        if (numTags > 1) estStdDevs = kMultiTagStdDevs;
+        if (numTags > 1)
+            estStdDevs = kMultiTagStdDevs;
         // Increase std devs based on (average) distance
         if (numTags == 1 && avgDist > 4)
             estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
-        else estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 30));
+        else
+            estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 30));
 
         return estStdDevs;
     }
@@ -157,12 +174,81 @@ public class Vision {
 
     /** Reset pose history of the robot in the vision system simulation. */
     public void resetSimPose(Pose2d pose) {
-        if (Robot.isSimulation()) visionSim.resetRobotPose(pose);
+        if (Robot.isSimulation())
+            visionSim.resetRobotPose(pose);
     }
 
     /** A Field2d for visualizing our robot and objects on the field. */
     public Field2d getSimDebugField() {
-        if (!Robot.isSimulation()) return null;
+        if (!Robot.isSimulation())
+            return null;
         return visionSim.getDebugField();
     }
+
+    public double getChosenTargetRotation(int targetID) {
+        var result = getLatestCameraResult();
+        // Get a list of all of the targets that have been detected.
+        List<PhotonTrackedTarget> targets = result.getTargets();
+        double rotation = 0;
+
+        // For each target we have check if it matches the id you want.
+        for (PhotonTrackedTarget target : targets) {
+            if (result.hasTargets()) {
+                if (target.getFiducialId() == targetID) {
+                    // Use the value of target to find our rotation using the getYaw command
+                    return target.getYaw();
+                }
+            } else {
+                rotation = 0;
+            }
+        }
+
+        return rotation;
+    }
+
+    public double getChosenTargetRange(int targetID)
+  {
+    var result = getLatestCameraResult();
+    List<PhotonTrackedTarget> targets = result.getTargets();
+    double range = 0;
+    double forwardSpeed = 0;
+
+    for(PhotonTrackedTarget target : targets)
+    {
+      if(result.hasTargets())
+      {
+        range =
+                        PhotonUtils.calculateDistanceToTargetMeters(
+                                CAMERA_HEIGHT_METERS, // Previously declarde
+                                TARGET_HEIGHT_METERS,
+                                CAMERA_PITCH_RADIANS,
+                                Units.degreesToRadians(target.getPitch()));
+
+                // THE FOLLOWING EQUATION CAN BE USED TO CALCULATE FORWARD SPEED
+                // Use this range as the measurement we give to the PID controller.
+                // -1.0 required to ensure positive PID controller effort _increases_ range
+                forwardSpeed = -DriveSubsystem.turnController.calculate(range, VisionConstants.GOAL_RANGE_METERS);
+                forwardSpeed *= Constants.kRangeSpeedOffset;
+      }
+      else
+      {
+        // If we have no targets, stay still
+        range = 0;
+      }
+    }
+
+    return forwardSpeed; 
+  }
+    // public double getChosenTargetRotation(int targetID) {
+    // // TODO Auto-generated method stub
+    // throw new UnsupportedOperationException("Unimplemented method
+    // 'getChosenTargetRotation'");
+    // }
+
+    // public double getChosenTargetRange(int targetID) {
+    // // TODO Auto-generated method stub
+    // throw new UnsupportedOperationException("Unimplemented method
+    // 'getChosenTargetRange'");
+    // }
+
 }

--- a/src/main/java/frc/robot/commands/GetChosenTarget.java
+++ b/src/main/java/frc/robot/commands/GetChosenTarget.java
@@ -2,23 +2,31 @@ package frc.robot.commands;
 
 import org.photonvision.PhotonCamera;
 
+import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.Constants;
+import frc.robot.Vision;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.Navigation;
 
 public class GetChosenTarget extends Command {
   /** Creates a new GetBestTarget. */
-private final Navigation m_vision;
+private final Vision m_vision;
 private final DriveSubsystem m_drive;
 private SendableChooser<Integer> m_chooser;
 
-  public GetChosenTarget(Navigation vision, DriveSubsystem drive) {
+final double ANGULAR_P = 0.1;
+final double ANGULAR_D = 0.0;
+PIDController turnController = new PIDController(ANGULAR_P, 0, ANGULAR_D);
+
+  public GetChosenTarget(Vision vision, DriveSubsystem drive) {
     m_drive = drive;
     m_vision = vision;
+    addRequirements(drive);
   }
 
   // Called when the command is initially scheduled.
@@ -31,6 +39,7 @@ private SendableChooser<Integer> m_chooser;
     int targetID = 5; //m_chooser.getSelected().intValue();
     double rotation = m_vision.getChosenTargetRotation(targetID);
     double speed = m_vision.getChosenTargetRange(targetID);
+    rotation = -turnController.calculate(rotation, 0) * Constants.kRangeSpeedOffset;
     if(speed > 0.5)
     {
       speed = 0.5;

--- a/src/main/java/frc/robot/commands/GetChosenTarget.java
+++ b/src/main/java/frc/robot/commands/GetChosenTarget.java
@@ -1,0 +1,63 @@
+package frc.robot.commands;
+
+import org.photonvision.PhotonCamera;
+
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.Navigation;
+
+public class GetChosenTarget extends Command {
+  /** Creates a new GetBestTarget. */
+private final Navigation m_vision;
+private final DriveSubsystem m_drive;
+private SendableChooser<Integer> m_chooser;
+
+  public GetChosenTarget(Navigation vision, DriveSubsystem drive, SendableChooser<Integer> chooserID) {
+    m_drive = drive;
+    m_vision = vision;
+    m_chooser = chooserID;
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    int targetID = m_chooser.getSelected().intValue();
+    double rotation = m_vision.getChosenTargetRotation(targetID);
+    double speed = m_vision.getChosenTargetRange(targetID);
+    if(speed > 0.5)
+    {
+      speed = 0.5;
+    }
+    else if (speed < -0.5) {
+      speed = -0.5;    
+    }
+
+    SmartDashboard.putNumber("Sim-Robot (Vision) Chosen Target Speed", speed);
+    SmartDashboard.putNumber("Sim-Robot (Vision) Chosen Target Rotation", rotation);
+    if(rotation != 0)
+    {
+      m_drive.drive(speed, 0, rotation, false);
+    }
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    Commands.print("Command ended = " + interrupted);
+  }
+
+  // Returns true when the command should end.
+  //@Override
+  /*public boolean isFinished() {
+    return;
+  }*/
+  
+}

--- a/src/main/java/frc/robot/commands/GetChosenTarget.java
+++ b/src/main/java/frc/robot/commands/GetChosenTarget.java
@@ -16,10 +16,9 @@ private final Navigation m_vision;
 private final DriveSubsystem m_drive;
 private SendableChooser<Integer> m_chooser;
 
-  public GetChosenTarget(Navigation vision, DriveSubsystem drive, SendableChooser<Integer> chooserID) {
+  public GetChosenTarget(Navigation vision, DriveSubsystem drive) {
     m_drive = drive;
     m_vision = vision;
-    m_chooser = chooserID;
   }
 
   // Called when the command is initially scheduled.
@@ -29,7 +28,7 @@ private SendableChooser<Integer> m_chooser;
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    int targetID = m_chooser.getSelected().intValue();
+    int targetID = 5; //m_chooser.getSelected().intValue();
     double rotation = m_vision.getChosenTargetRotation(targetID);
     double speed = m_vision.getChosenTargetRange(targetID);
     if(speed > 0.5)

--- a/src/main/java/frc/robot/commands/GrabNote.java
+++ b/src/main/java/frc/robot/commands/GrabNote.java
@@ -6,7 +6,7 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.ParallelRaceGroup;
-import frc.robot.Constants.Vision;
+import frc.robot.Constants.VisionConstants;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.Intake;
 import frc.robot.subsystems.DriveSubsystem;

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -427,10 +427,8 @@ public class DriveSubsystem extends SubsystemBase {
     m_fieldOriented = !m_fieldOriented;
     return m_fieldOriented;
   }
-//PID Controllers
-public static PIDController turnController = new PIDController(Constants.ANGULAR_P, 0, Constants.ANGULAR_D);
 
-public PhotonPipelineResult getLatestCameraResult() {
-  return m_simVision.getLatestResult(Constants.Vision.kCameraNameNote);
-}
+  //PID Controllers
+  public static PIDController turnController = new PIDController(Constants.ANGULAR_P, 0, Constants.ANGULAR_D);
+
 }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -102,7 +102,7 @@ public class DriveSubsystem extends SubsystemBase {
       DriverStation.reportError("Error instantiating navX-MXP:  " + ex.getMessage(), true);
     }
 
-    m_gyro.setAngleAdjustment(180.0);
+    //m_gyro.setAngleAdjustment(180.0);
     m_gyro.zeroYaw();
 
     if (RobotBase.isSimulation()) {

--- a/src/main/java/frc/robot/subsystems/Navigation.java
+++ b/src/main/java/frc/robot/subsystems/Navigation.java
@@ -12,6 +12,7 @@ import org.photonvision.targeting.PhotonTrackedTarget;
 
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 
@@ -49,7 +50,7 @@ public class Navigation extends SubsystemBase {
     {
       // Calculate angular turn power
       // Remove -1.0 because it was inverting results.
-      rotation = -turnController.calculate(result.getBestTarget().getYaw(), 0) * Constants.kRangeSpeedOffset;
+      rotation = turnController.calculate(result.getBestTarget().getYaw(), 0) * Constants.kRangeSpeedOffset;
 
   } else {
       // If we have no targets, stay still.
@@ -151,6 +152,10 @@ public class Navigation extends SubsystemBase {
   @Override
   public void periodic() {
     // This method will be called once per scheduler run
+    if(m_drive.getLatestCameraResult().hasTargets())
+    {
+    SmartDashboard.putNumber("Current Fiducial Id:", m_drive.getLatestCameraResult().getBestTarget().getFiducialId());
+    }
   }
 
   public void setDriveController(DriveSubsystem robotDrive) {

--- a/src/main/java/frc/robot/subsystems/NoteFinder.java
+++ b/src/main/java/frc/robot/subsystems/NoteFinder.java
@@ -8,7 +8,7 @@
 
 package frc.robot.subsystems;
 
-import static frc.robot.Constants.Vision.kCameraNameNote;
+import static frc.robot.Constants.VisionConstants.kCameraNameNote;
 
 import org.photonvision.PhotonUtils;
 
@@ -48,7 +48,7 @@ public class NoteFinder extends SubsystemBase {
 
   public double getRotation()
   {
-    var result = m_vision.getLatestResult(kCameraNameNote);
+    var result = m_vision.getLatestResult();
     double rotation;
     if (result.hasTargets()) 
     {
@@ -66,7 +66,7 @@ public class NoteFinder extends SubsystemBase {
   // HEADER - METHOD TO FIND DISTANCE FROM TARGET
   public double getRange()
   {
-    var result = m_vision.getLatestResult(kCameraNameNote);
+    var result = m_vision.getLatestResult();
     double range;
     if (result.hasTargets()) {
                 // First calculate range
@@ -93,7 +93,7 @@ public class NoteFinder extends SubsystemBase {
 
   public double getDistance()
   {
-    var result = m_vision.getLatestResult(kCameraNameNote);
+    var result = m_vision.getLatestResult();
     double range;
     if (result.hasTargets()) {
                 // First calculate range


### PR DESCRIPTION
Now create individual vision instance for each camera. 
Still some tidy up to do, but note finder and April tag detection were tested using these changes.
To do: allow for separate camera parameters during initialization